### PR TITLE
Restore release environment for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,8 @@ jobs:
     name: 🚀 Release
     needs: [build-release-artifact]
     runs-on: ubuntu-latest
+    environment:
+      name: production
     permissions:
       contents: write # to be able to publish a GitHub release
       id-token: write # to enable use of OIDC for npm provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: ${{ github.repository == 'epicweb-dev/epicli' && github.event_name == 'push' }}
+    if: >-
+      ${{
+        github.repository == 'epicweb-dev/epicli' &&
+        github.event_name == 'push' &&
+        (contains(fromJSON('["main","next","next-major","beta","alpha"]'), github.ref_name) ||
+          endsWith(github.ref_name, '.x'))
+      }}
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -90,7 +96,13 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
       issues: write # to be able to comment on released issues
       pull-requests: write # to be able to comment on released pull requests
-    if: ${{ github.repository == 'epicweb-dev/epicli' && github.event_name == 'push' }}
+    if: >-
+      ${{
+        github.repository == 'epicweb-dev/epicli' &&
+        github.event_name == 'push' &&
+        (contains(fromJSON('["main","next","next-major","beta","alpha"]'), github.ref_name) ||
+          endsWith(github.ref_name, '.x'))
+      }}
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- restore the `production` environment on the publish-authorized release job
- keep npm OIDC/id-token permissions scoped to the release job
- gate release artifact and publish jobs to semantic-release branches so feature-branch pushes do not request production deployment

## Context

The failing release run reached `@semantic-release/npm` verification and npm rejected the OIDC exchange before falling back to an invalid placeholder token. The previous successful release workflow used the `production` environment, which is part of the npm trusted publishing identity when configured.

The first branch push for this fix also showed the hardened workflow was requesting the `production` environment on feature branches. The release jobs now skip non-release branches while preserving `main`, prerelease branches, `next-major`, and maintenance `.x` branches.

## Testing

- `npm ci --ignore-scripts`
- `npm run test -- --run`
- `npm run typecheck`
- `npm run build`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`
- PR checks: test/typecheck passed; release artifact and release jobs skipped on the feature branch as expected

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddc85524-8435-4fd3-b8cf-8b1317208d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddc85524-8435-4fd3-b8cf-8b1317208d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

